### PR TITLE
Update readme and rename examples svg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # lc-render
 
+Library to create charts images
+
 ## Examples
 
-You can find examples in `examples` directory.  
+You can find examples in [examples](https://github.com/limpidchart/lc-render/tree/main/examples) directory.  
 Use `cargo run` to create charts from them:
 
 ```sh
-cargo run --example vertical_bar_chart
+cargo run --example stacked_vertical_bar_chart
 ```
 
-All examples create images in `svg` directory.  
-The command above creates the following chart:
+All examples create images in [examples/svg](https://github.com/limpidchart/lc-render/tree/main/examples/svg) directory.  
+You can see some of them here:
 
-![alt text](./examples/svg/vertical_chart.svg)
+![alt text](./examples/svg/line_and_vertical_bar_chart.svg)
+![alt text](./examples/svg/stacked_vertical_bar_chart.svg)
 
 ## Benchmarks
 
@@ -98,9 +101,13 @@ ten_scatters_chart/10000   time:   [123.34 ms 123.62 ms 123.91 ms]
 ten_scatters_chart/100000  time:   [1.3547 s 1.3564 s 1.3582 s]
 ten_scatters_chart/1000000 time:   [13.507 s 13.520 s 13.533 s]
 
-vertical_bar_chart/100     time:    224.81 us 225.58 us 226.75 us]
-vertical_bar_chart/1000    time:    2.1700 ms 2.1746 ms 2.1795 ms]
+vertical_bar_chart/100     time:   [224.81 us 225.58 us 226.75 us]
+vertical_bar_chart/1000    time:   [2.1700 ms 2.1746 ms 2.1795 ms]
 vertical_bar_chart/10000   time:   [24.008 ms 24.067 ms 24.129 ms]
 vertical_bar_chart/100000  time:   [337.56 ms 338.45 ms 339.36 ms]
 vertical_bar_chart/1000000 time:   [5.2513 s 5.2616 s 5.2718 s]
 ```
+
+# Thanks
+
+SVG drawing logic is based on [rustplotlib](https://github.com/askanium/rustplotlib). Big thanks to them!

--- a/examples/horizontal_bar_chart.rs
+++ b/examples/horizontal_bar_chart.rs
@@ -53,6 +53,6 @@ fn main() {
         .add_view(&view);
 
     chart
-        .save("./examples/svg/horizontal_chart.svg")
-        .expect("unable to save ./svg/horizontal_chart.svg");
+        .save("./examples/svg/horizontal_bar_chart.svg")
+        .expect("unable to save ./svg/horizontal_bar_chart.svg");
 }

--- a/examples/line_and_vertical_bar_chart.rs
+++ b/examples/line_and_vertical_bar_chart.rs
@@ -63,6 +63,6 @@ fn main() {
         .add_view(&line_view);
 
     chart
-        .save("./examples/svg/line_and_vertical_chart.svg")
+        .save("./examples/svg/line_and_vertical_bar_chart.svg")
         .expect("unable to save ./svg/line_and_vertical_chart.svg");
 }

--- a/examples/stacked_horizontal_bar_chart.rs
+++ b/examples/stacked_horizontal_bar_chart.rs
@@ -68,6 +68,6 @@ fn main() {
         .add_view(&view);
 
     chart
-        .save("./examples/svg/stacked_horizontal_chart.svg")
-        .expect("unable to save ./examples/svg/stacked_horizontal_chart.svg");
+        .save("./examples/svg/stacked_horizontal_bar_chart.svg")
+        .expect("unable to save ./examples/svg/stacked_horizontal_bar_chart.svg");
 }

--- a/examples/stacked_vertical_bar_chart.rs
+++ b/examples/stacked_vertical_bar_chart.rs
@@ -68,6 +68,6 @@ fn main() {
         .add_view(&view);
 
     chart
-        .save("./examples/svg/stacked_vertical_chart.svg")
-        .expect("unable to save ./examples/svg/stacked_vertical_chart.svg");
+        .save("./examples/svg/stacked_vertical_bar_chart.svg")
+        .expect("unable to save ./examples/svg/stacked_vertical_bar_chart.svg");
 }

--- a/examples/svg/horizontal_bar_chart.svg
+++ b/examples/svg/horizontal_bar_chart.svg
@@ -110,16 +110,10 @@ Values
 </g>
 <g class="views" transform="translate(60,90)">
 <g>
-<g class="bar" transform="translate(0,369.80392)">
-<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="66.5" x="0" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="33.25" y="40.588238">
-9.5
-</text>
-</g>
-<g class="bar" transform="translate(0,99.215675)">
-<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="84" x="0" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="42" y="40.588238">
-12
+<g class="bar" transform="translate(0,189.41176)">
+<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="243.59999" x="0" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="121.799995" y="40.588238">
+34.8
 </text>
 </g>
 <g class="bar" transform="translate(0,9.019592)">
@@ -128,16 +122,22 @@ Values
 92
 </text>
 </g>
-<g class="bar" transform="translate(0,189.41176)">
-<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="243.59999" x="0" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="121.799995" y="40.588238">
-34.8
+<g class="bar" transform="translate(0,99.215675)">
+<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="84" x="0" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="42" y="40.588238">
+12
 </text>
 </g>
 <g class="bar" transform="translate(0,279.60785)">
 <rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="168" x="0" y="0"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="84" y="40.588238">
 24
+</text>
+</g>
+<g class="bar" transform="translate(0,369.80392)">
+<rect fill="#898fd5" height="81.176476" shape-rendering="crispEdges" stroke="#2c2663" stroke-width="1" width="66.5" x="0" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="33.25" y="40.588238">
+9.5
 </text>
 </g>
 </g>

--- a/examples/svg/line_and_vertical_bar_chart.svg
+++ b/examples/svg/line_and_vertical_bar_chart.svg
@@ -104,34 +104,10 @@
 </g>
 <g class="views" transform="translate(60,90)">
 <g>
-<g class="bar" transform="translate(305.6338,0)">
-<rect fill="#77ab59" height="402.20236" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="57.797638"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="258.8988">
-74.32
-</text>
-</g>
-<g class="bar" transform="translate(502.8169,0)">
-<rect fill="#77ab59" height="350.46588" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="109.53412"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="284.76706">
-64.76
-</text>
-</g>
-<g class="bar" transform="translate(601.40845,0)">
-<rect fill="#77ab59" height="392.46115" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="67.53885"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="263.7694">
-72.52
-</text>
-</g>
 <g class="bar" transform="translate(108.45068,0)">
 <rect fill="#77ab59" height="359.01645" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="100.98355"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="280.49176">
 66.34
-</text>
-</g>
-<g class="bar" transform="translate(404.22534,0)">
-<rect fill="#77ab59" height="371.3553" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="88.644714"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="274.32236">
-68.62
 </text>
 </g>
 <g class="bar" transform="translate(207.04224,0)">
@@ -140,10 +116,34 @@
 64.18
 </text>
 </g>
+<g class="bar" transform="translate(502.8169,0)">
+<rect fill="#77ab59" height="350.46588" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="109.53412"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="284.76706">
+64.76
+</text>
+</g>
+<g class="bar" transform="translate(404.22534,0)">
+<rect fill="#77ab59" height="371.3553" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="88.644714"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="274.32236">
+68.62
+</text>
+</g>
+<g class="bar" transform="translate(601.40845,0)">
+<rect fill="#77ab59" height="392.46115" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="67.53885"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="263.7694">
+72.52
+</text>
+</g>
 <g class="bar" transform="translate(9.859131,0)">
 <rect fill="#77ab59" height="404.36707" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="55.632935"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="257.81647">
 74.72
+</text>
+</g>
+<g class="bar" transform="translate(305.6338,0)">
+<rect fill="#77ab59" height="402.20236" shape-rendering="crispEdges" stroke="#36802d" stroke-width="1" width="88.73239" x="0" y="57.797638"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="44.366196" y="258.8988">
+74.32
 </text>
 </g>
 </g>

--- a/examples/svg/stacked_horizontal_bar_chart.svg
+++ b/examples/svg/stacked_horizontal_bar_chart.svg
@@ -104,42 +104,6 @@ Australia
 </g>
 <g class="views" transform="translate(100,90)">
 <g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="137.44711" x="0" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="68.72356" y="48.688526">
-71.92
-</text>
-</g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#00fff9" height="97.37705" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="78.62309" x="137.44711" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="176.75867" y="48.688526">
-41.14
-</text>
-</g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#3f962c" height="97.37705" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="109.33467" x="216.0702" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="270.73755" y="48.688526">
-57.21
-</text>
-</g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#5eab2e" height="97.37705" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="134.23642" x="325.40488" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="392.52307" y="48.688526">
-70.24
-</text>
-</g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#ffa700" height="97.37705" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="132.66937" x="459.6413" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="525.97595" y="48.688526">
-69.42
-</text>
-</g>
-<g class="bar" transform="translate(0,443.60657)">
-<rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="196.04181" x="592.31067" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="690.33154" y="48.688526">
-102.58
-</text>
-</g>
 <g class="bar" transform="translate(0,335.40985)">
 <rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="133.93066" x="0" y="0"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="66.96533" y="48.688526">
@@ -176,6 +140,42 @@ Australia
 82.76
 </text>
 </g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="160.80089" x="0" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="80.400444" y="48.688526">
+84.14
+</text>
+</g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#00fff9" height="97.37705" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="73.348465" x="160.80089" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="197.47513" y="48.688526">
+38.38
+</text>
+</g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#3f962c" height="97.37705" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="119.02399" x="234.14935" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="293.66135" y="48.688526">
+62.28
+</text>
+</g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#5eab2e" height="97.37705" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="155.06757" x="353.17334" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="430.70712" y="48.688526">
+81.14
+</text>
+</g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#ffa700" height="97.37705" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="145.77954" x="508.2409" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="581.1307" y="48.688526">
+76.28
+</text>
+</g>
+<g class="bar" transform="translate(0,551.80334)">
+<rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="189.75421" x="654.02045" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="748.8976" y="48.688526">
+99.29
+</text>
+</g>
 <g class="bar" transform="translate(0,227.21312)">
 <rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="150.28978" x="0" y="0"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="75.14489" y="48.688526">
@@ -210,6 +210,42 @@ Australia
 <rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="160.32318" x="613.5622" y="0"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="693.72375" y="48.688526">
 83.89
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="137.44711" x="0" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="68.72356" y="48.688526">
+71.92
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#00fff9" height="97.37705" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="78.62309" x="137.44711" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="176.75867" y="48.688526">
+41.14
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#3f962c" height="97.37705" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="109.33467" x="216.0702" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="270.73755" y="48.688526">
+57.21
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#5eab2e" height="97.37705" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="134.23642" x="325.40488" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="392.52307" y="48.688526">
+70.24
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#ffa700" height="97.37705" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="132.66937" x="459.6413" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="525.97595" y="48.688526">
+69.42
+</text>
+</g>
+<g class="bar" transform="translate(0,443.60657)">
+<rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="196.04181" x="592.31067" y="0"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="690.33154" y="48.688526">
+102.58
 </text>
 </g>
 <g class="bar" transform="translate(0,10.819672)">
@@ -282,42 +318,6 @@ Australia
 <rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="179.10938" x="517.89197" y="0"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="607.44666" y="48.688526">
 93.72
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#01629c" height="97.37705" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="160.80089" x="0" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="80.400444" y="48.688526">
-84.14
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#00fff9" height="97.37705" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="73.348465" x="160.80089" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="197.47513" y="48.688526">
-38.38
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#3f962c" height="97.37705" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="119.02399" x="234.14935" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="293.66135" y="48.688526">
-62.28
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#5eab2e" height="97.37705" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="155.06757" x="353.17334" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="430.70712" y="48.688526">
-81.14
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#ffa700" height="97.37705" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="145.77954" x="508.2409" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="581.1307" y="48.688526">
-76.28
-</text>
-</g>
-<g class="bar" transform="translate(0,551.80334)">
-<rect fill="#ffce00" height="97.37705" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="189.75421" x="654.02045" y="0"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="748.8976" y="48.688526">
-99.29
 </text>
 </g>
 </g>

--- a/examples/svg/stacked_vertical_bar_chart.svg
+++ b/examples/svg/stacked_vertical_bar_chart.svg
@@ -140,42 +140,6 @@ Australia
 99.29
 </text>
 </g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#01629c" height="63.39154" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="103.27869" x="0" y="796.60846"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="828.3042">
-33.17
-</text>
-</g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#00fff9" height="18.67157" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="103.27869" x="0" y="777.9369"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="787.2727">
-9.77
-</text>
-</g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#3f962c" height="42.02533" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="103.27869" x="0" y="735.91156"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="756.9242">
-21.99
-</text>
-</g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#5eab2e" height="53.14801" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="103.27869" x="0" y="682.76355"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="709.3375">
-27.81
-</text>
-</g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#ffa700" height="58.57556" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="103.27869" x="0" y="624.188"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="653.47577">
-30.65
-</text>
-</g>
-<g class="bar" transform="translate(11.475403,0)">
-<rect fill="#ffce00" height="66.143555" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="103.27869" x="0" y="558.04443"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="591.1162">
-34.61
-</text>
-</g>
 <g class="bar" transform="translate(126.2295,0)">
 <rect fill="#01629c" height="134.96265" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="103.27869" x="0" y="725.03735"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="792.5187">
@@ -246,6 +210,42 @@ Australia
 <rect fill="#ffce00" height="158.16357" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="103.27869" x="0" y="153.08002"/>
 <text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="232.1618">
 82.76
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#01629c" height="63.39154" shape-rendering="crispEdges" stroke="#00296f" stroke-width="1" width="103.27869" x="0" y="796.60846"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="828.3042">
+33.17
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#00fff9" height="18.67157" shape-rendering="crispEdges" stroke="#00a2c5" stroke-width="1" width="103.27869" x="0" y="777.9369"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="787.2727">
+9.77
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#3f962c" height="42.02533" shape-rendering="crispEdges" stroke="#13761f" stroke-width="1" width="103.27869" x="0" y="735.91156"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="756.9242">
+21.99
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#5eab2e" height="53.14801" shape-rendering="crispEdges" stroke="#168523" stroke-width="1" width="103.27869" x="0" y="682.76355"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="709.3375">
+27.81
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#ffa700" height="58.57556" shape-rendering="crispEdges" stroke="#ff7400" stroke-width="1" width="103.27869" x="0" y="624.188"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="653.47577">
+30.65
+</text>
+</g>
+<g class="bar" transform="translate(11.475403,0)">
+<rect fill="#ffce00" height="66.143555" shape-rendering="crispEdges" stroke="#ff8d00" stroke-width="1" width="103.27869" x="0" y="558.04443"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="51.639343" y="591.1162">
+34.61
 </text>
 </g>
 <g class="bar" transform="translate(470.4918,0)">

--- a/examples/svg/vertical_bar_chart.svg
+++ b/examples/svg/vertical_bar_chart.svg
@@ -110,10 +110,10 @@ Values
 </g>
 <g class="views" transform="translate(60,90)">
 <g>
-<g class="bar" transform="translate(288.2353,0)">
-<rect fill="#36896e" height="160.08002" shape-rendering="crispEdges" stroke="#0c513b" stroke-width="1" width="123.5294" x="0" y="299.91998"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="61.7647" y="379.96">
-34.8
+<g class="bar" transform="translate(13.725494,0)">
+<rect fill="#36896e" height="423.2" shape-rendering="crispEdges" stroke="#0c513b" stroke-width="1" width="123.5294" x="0" y="36.799988"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="61.7647" y="248.4">
+92
 </text>
 </g>
 <g class="bar" transform="translate(425.4902,0)">
@@ -122,10 +122,10 @@ Values
 24
 </text>
 </g>
-<g class="bar" transform="translate(13.725494,0)">
-<rect fill="#36896e" height="423.2" shape-rendering="crispEdges" stroke="#0c513b" stroke-width="1" width="123.5294" x="0" y="36.799988"/>
-<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="61.7647" y="248.4">
-92
+<g class="bar" transform="translate(288.2353,0)">
+<rect fill="#36896e" height="160.08002" shape-rendering="crispEdges" stroke="#0c513b" stroke-width="1" width="123.5294" x="0" y="299.91998"/>
+<text dy=".35em" fill="#080808" font-family="sans-serif" font-size="14px" text-anchor="middle" x="61.7647" y="379.96">
+34.8
 </text>
 </g>
 <g class="bar" transform="translate(150.9804,0)">

--- a/examples/vertical_bar_chart.rs
+++ b/examples/vertical_bar_chart.rs
@@ -53,6 +53,6 @@ fn main() {
         .add_view(&view);
 
     chart
-        .save("./examples/svg/vertical_chart.svg")
-        .expect("unable to save ./svg/vertical_chart.svg");
+        .save("./examples/svg/vertical_bar_chart.svg")
+        .expect("unable to save ./svg/vertical_bar_chart.svg");
 }


### PR DESCRIPTION
Use line_and_vertical_bar_chart, stacked_vertical_bar_chart as examples
in README.md.

Add link to rustplotlib.

Add the description.

Use better formatting for the benchmarks results.

Use same filenames for SVG examples as for the Rust code files.