### PR TITLE
Remove wrong comment in horizontal chart example

### DIFF
--- a/examples/horizontal_bar_chart.rs
+++ b/examples/horizontal_bar_chart.rs
@@ -25,7 +25,6 @@ fn main() {
     );
 
     // Configure horizontal scale.
-    // LinearScale range is inverted because SVG coordinate system's origin is at left top corner.
     let x_scale = LinearScale::new(0.0, 100.0, 0, width - margin_left - margin_right);
 
     // Prepare vertical bars data.


### PR DESCRIPTION
Remove comment about inverted range since it's not inverted in that
example.